### PR TITLE
moving api keys out of repo

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,9 +11,19 @@ android {
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
+        debug {
+            buildConfigField 'String', "clientId", SpotifyGuesser_clientId
+            resValue 'string', "client_id", SpotifyGuesser_clientId
+            buildConfigField 'String', "clientSecret", SpotifyGuesser_clientSecret
+            resValue 'string', "client_secret", SpotifyGuesser_clientSecret
+        }
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            buildConfigField 'String', "clientId", SpotifyGuesser_clientId
+            resValue 'string', "client_id", SpotifyGuesser_clientId
+            buildConfigField 'String', "clientSecret", SpotifyGuesser_clientSecret
+            resValue 'string', "client_secret", SpotifyGuesser_clientSecret
         }
     }
 }

--- a/app/src/main/java/com/example/guessthatname/utils/NetworkUtils.java
+++ b/app/src/main/java/com/example/guessthatname/utils/NetworkUtils.java
@@ -5,6 +5,8 @@ import android.util.Base64;
 import android.util.Log;
 import android.util.Xml;
 
+import com.example.guessthatname.BuildConfig;
+
 import java.io.IOException;
 import java.util.prefs.BackingStoreException;
 
@@ -18,8 +20,8 @@ import okhttp3.Response;
 public class NetworkUtils {
 
     private static final OkHttpClient mHTTPClient = new OkHttpClient();
-    public static final String client_secret = "61f03839c7eb427285916862a226058f";
-    public static final String client_id = "550e72b9edba4d4a96e4f903436e1130";
+    public static final String client_secret = BuildConfig.clientSecret;
+    public static final String client_id = BuildConfig.clientId;
 
     public static String doHTTPGet(String url, String token) throws IOException {
         Request request = new Request.Builder()

--- a/app/src/main/res/values/secrets.xml
+++ b/app/src/main/res/values/secrets.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="client_id">550e72b9edba4d4a96e4f903436e1130</string>
-    <string name="client_secret">61f03839c7eb427285916862a226058f</string>
-</resources>


### PR DESCRIPTION
### Steps to get working

- remove secrets.xml from the values resource directory
- edit the file gradle.properties in `C:\Users\<Your Username>\.gradle` (create if doesn't exist)
- put in the values:
```
SpotifyGuesser_clientId="{client id from Brett}"
SpotifyGuesser_clientSecret="{client secret from Brett}"
```
- go back to the repo and in build.gradle make sure your build types tag looks like this
```
buildTypes {
        debug {
            buildConfigField 'String', "clientId", SpotifyGuesser_clientId
            resValue 'string', "client_id", SpotifyGuesser_clientId
            buildConfigField 'String', "clientSecret", SpotifyGuesser_clientSecret
            resValue 'string', "client_secret", SpotifyGuesser_clientSecret
        }
        release {
            minifyEnabled false
            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
            buildConfigField 'String', "clientId", SpotifyGuesser_clientId
            resValue 'string', "client_id", SpotifyGuesser_clientId
            buildConfigField 'String', "clientSecret", SpotifyGuesser_clientSecret
            resValue 'string', "client_secret", SpotifyGuesser_clientSecret
        }
}
```
- use the api key now by typing `BuildConfig.clientSecret` or `BuildConfig.clientId`
